### PR TITLE
add function to reset statically allocated data structures in L1

### DIFF
--- a/include/vmm/vmm.h
+++ b/include/vmm/vmm.h
@@ -83,4 +83,11 @@ int unmap_page(const void* const virt_ptr);
  */
 int handle_rab_misses();
 
+/**
+ * Reset all relevant VMM data structures statically allocated in L1 memory.
+ *
+ * This function must be called in case the L1 memory is not loaded.
+ */
+void reset_vmm();
+
 #endif

--- a/src/vmm.c
+++ b/src/vmm.c
@@ -45,6 +45,17 @@ typedef struct mht_t {
     static unsigned char page_rab_cfg_l2_i_set[RAB_L2_N_SETS] = {0};
 #endif
 
+static inline void reset_page_rab_cfg_ptrs()
+{
+    page_rab_cfg_ptr = RAB_CFG_VMM_BPTR;
+
+    #if (VMM_RAB_LVL == 2)
+        for (unsigned i=0; i<RAB_L2_N_SETS; i++) {
+            page_rab_cfg_l2_i_set[i] = 0;
+        }
+    #endif
+}
+
 static inline int config_page_rab_entry(const virt_addr_t page_virt_addr,
         const phys_addr_t* const page_phys_addr, const unsigned char page_rdonly,
         const unsigned char cache_coherent)
@@ -414,5 +425,5 @@ void reset_vmm()
 {
     reset_recently_mapped_pages();
 
-    page_rab_cfg_ptr = RAB_CFG_VMM_BPTR;
+    reset_page_rab_cfg_ptrs();
 }

--- a/src/vmm.c
+++ b/src/vmm.c
@@ -186,6 +186,14 @@ static virt_addr_t recently_mapped_pages[ARCHI_NB_PE] = {0};
 virt_addr_t* const rmp_eptr = recently_mapped_pages + ARCHI_NB_PE;
 virt_addr_t*       rmp_wptr = recently_mapped_pages;
 
+static inline void reset_recently_mapped_pages()
+{
+    for (unsigned i=0; i<ARCHI_NB_PE; i++) {
+        recently_mapped_pages[i] = 0;
+    }
+    rmp_wptr = recently_mapped_pages;
+}
+
 static inline unsigned page_has_recently_been_mapped(const virt_addr_t page_addr)
 {
     for (const virt_addr_t* rmp_rptr = recently_mapped_pages; rmp_rptr < rmp_eptr; ++rmp_rptr) {
@@ -400,4 +408,11 @@ int handle_rab_misses()
             ++n_misses_handled;
         }
     }
+}
+
+void reset_vmm()
+{
+    reset_recently_mapped_pages();
+
+    page_rab_cfg_ptr = RAB_CFG_VMM_BPTR;
 }


### PR DESCRIPTION
This pull request adds the functionality to reset all relevant VMM data structures statically allocated in L1 memory. This is needed if the L1 memory is not loaded as it is currently the case on HERO.